### PR TITLE
STEP10

### DIFF
--- a/src/test/java/kr/hhplus/be/server/integration/ReservationFacadeConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/ReservationFacadeConcurrencyTest.java
@@ -1,0 +1,96 @@
+package kr.hhplus.be.server.integration;
+
+import kr.hhplus.be.server.application.reservation.ReservationFacade;
+import kr.hhplus.be.server.domain.concert.ConcertSchedule;
+import kr.hhplus.be.server.domain.concert.ConcertScheduleRepository;
+import kr.hhplus.be.server.domain.concert.ConcertSeat;
+import kr.hhplus.be.server.domain.concert.ConcertSeatRepository;
+import kr.hhplus.be.server.domain.queue.QueueService;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.domain.user.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+@SpringBootTest
+public class ReservationFacadeConcurrencyTest {
+
+    @Autowired
+    ReservationFacade reservationFacade;
+
+    @Autowired
+    QueueService queueService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ConcertScheduleRepository concertScheduleRepository;
+
+    @Autowired
+    ConcertSeatRepository concertSeatRepository;
+
+
+    @Test
+    void 동시예약시_5명중_1명만_성공한다() throws InterruptedException, ExecutionException {
+        // given - 필요 데이터 삽입
+        // 유저 저장
+        User user = userRepository.save(User.builder()
+                .balance(10000L)
+                .username("testUser")
+                .build());
+        // 콘서트 스케줄 저장
+        ConcertSchedule concertSchedule = concertScheduleRepository.save(ConcertSchedule.builder()
+                .concertDate(LocalDate.now())
+                .build());
+        // 콘서트 좌석 저장
+        ConcertSeat concertSeat = concertSeatRepository.save(ConcertSeat.builder()
+                .seatNo(1L)
+                .price(5000L)
+                .concertSchedule(concertSchedule)
+                        .status("available")
+                .build());
+
+        int threadCount = 5;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        List<Future<Boolean>> results = new ArrayList<>();
+
+        for(int i =0; i<threadCount;i++){
+            results.add(executorService.submit(()->{
+
+                try {
+                    reservationFacade.reserveSeat(user.getId(),concertSchedule.getId(),concertSeat.getSeatNo());
+                    return true;
+                } catch (Exception e){
+                    return false;
+                } finally {
+                    latch.countDown();
+                }
+            }));
+        }
+        // 대기
+        latch.await();
+        // 작업종료
+        executorService.shutdown();
+
+        // 성공 카운팅
+        int successCount = 0;
+        for(Future<Boolean>  result:results){
+            if(result.get()){
+                successCount++;
+            }
+        }
+        // 검증
+        Assertions.assertEquals(1,successCount);
+    }
+
+}

--- a/src/test/java/kr/hhplus/be/server/integration/ReservationFacadeTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/ReservationFacadeTest.java
@@ -129,62 +129,6 @@ public class ReservationFacadeTest {
     }
 
 
-//    @Test
-//    void 동시성_테스트_좌석_결제() throws InterruptedException, ExecutionException {
-//
-//        // given - 필요 데이터 삽입
-//        // 토큰 발급
-//        String uuid = queueService.getToken();
-//        // 유저 저장
-//        User user = userRepository.save(User.builder()
-//                .balance(10000L)
-//                .username("testUser")
-//                .build());
-//        // 콘서트 스케줄 저장
-//        ConcertSchedule concertSchedule = concertScheduleRepository.save(ConcertSchedule.builder()
-//                .concertDate(LocalDate.now())
-//                .build());
-//        // 콘서트 좌석 저장
-//        ConcertSeat concertSeat = concertSeatRepository.save(ConcertSeat.builder()
-//                .seatNo(1L)
-//                .price(5000L)
-//                .concertSchedule(concertSchedule)
-//                .build());
-//
-//        int threadCount = 10;
-//        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-//        CountDownLatch latch = new CountDownLatch(threadCount);
-//
-//        List<Future<Boolean>> results = new ArrayList<>();
-//
-//        for (int i = 0; i < threadCount; i++) {
-//            results.add(executorService.submit(() -> {
-//                latch.countDown(); // 모든 스레드가 준비될 때까지 대기
-//                latch.await();
-//                try {
-//                    // 좌석 예약
-//                    reservationFacade.reserveSeat(user.getId(), concertSchedule.getId(), concertSeat.getSeatNo());
-//                    return true; // 성공
-//                } catch (Exception e) {
-//                    return false; // 실패
-//                }
-//            }));
-//        }
-//
-//        executorService.shutdown();
-//        executorService.awaitTermination(10, TimeUnit.SECONDS);
-//
-//        // 테스트 결과 검증
-//        int successCount = 0;
-//        for (Future<Boolean> result : results) {
-//            if (result.get()) {
-//                successCount++;
-//            }
-//        }
-//
-//        // 한 번만 결제가 성공해야 함
-//        Assertions.assertEquals(1, successCount);
-//
-//    }
+
 
 }

--- a/src/test/java/kr/hhplus/be/server/unit/ConcertServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/unit/ConcertServiceTest.java
@@ -7,10 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -48,7 +45,7 @@ public class ConcertServiceTest {
                 .build();
         List<ConcertSchedule> mockList = new ArrayList<>();
         mockList.add(concertSchedule);
-        Pageable pageable = PageRequest.of(1, 10);
+        Pageable pageable = PageRequest.of(1, 10,Sort.by("concertDate"));
         Page<ConcertSchedule> mockPage = new PageImpl<>(mockList, pageable, mockList.size());
         given(concertScheduleRepository.findByConcertId(concertId, pageable))
                 .willReturn(mockPage);
@@ -101,7 +98,7 @@ public class ConcertServiceTest {
     void 특정콘서트ID가_주어졌지만_해당하는_스케줄이_없는경우_NoSuchElementException이_반환된다(){
         // given
         Long concertId = 1000L;
-        Pageable pageable = PageRequest.of(0, 10);
+        Pageable pageable = PageRequest.of(0, 10,Sort.by("concertDate"));
         given(concertScheduleRepository.findByConcertId(concertId,pageable))
                 .willReturn(new PageImpl<>(new ArrayList<>(),pageable,0));
 


### PR DESCRIPTION
### **커밋 링크**

예약 파사드 통시성 테스트 추가 :  1323dd6815f84cc4d95428287f357dff1efc308a

회고록 작성 : [회고록](https://velog.io/@babyslayerr/%ED%95%AD%ED%95%B4%ED%94%8C%EB%9F%AC%EC%8A%A4-%ED%9A%8C%EA%B3%A0%EB%A1%9D345-week)

---
### **리뷰 포인트(질문)**
- 예약 파사드 동시성 테스트의 로직은 작성했습니다, 아직 기존 비즈니스 로직에 동시성 제어는 하지 않았습니다(자신 없으면 다음주로 미루라고 하셔ㅅ...😶‍🌫️) 또한 파사드 테스트 로직(호출하는 서비스중에 ConcertService.reserveAvailableSeat)이 적절한지도 봐주셨으면 좋겠습니다. 감사합니다. :)

### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
계속 개발에 관심가지고 생각하기
### Problem
<!--개선이 필요한 점-->
커밋 로그 잘 구분해서 작성하기
### Try
<!-- 새롭게 시도할 점 -->
새로운 개념 배워보기
