### PR TITLE
STEP11+STEP12

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,10 @@ dependencies {
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
 	implementation("org.projectlombok:lombok")
 
+	// redisson
+	implementation("org.redisson:redisson-spring-boot-starter:3.18.0")
 
+	implementation ("org.springframework.boot:spring-boot-starter-aop")
 	// DB
 	runtimeOnly("com.mysql:mysql-connector-j")
 	// runtimeOnly("com.h2database:h2")
@@ -54,3 +57,6 @@ tasks.withType<Test> {
 	systemProperty("user.timezone", "UTC")
 }
 
+tasks.withType<JavaCompile> {
+	options.compilerArgs.add("-parameters")
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,19 @@ services:
       - MYSQL_DATABASE=hhplus
     volumes:
       - ./data/mysql/:/var/lib/mysql
-
+  redis:
+    image: docker.io/bitnami/redis:7.4
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
+    ports:
+      - "6379:6379"
+    volumes:
+      - "redis_data:/bitnami/redis/data"
 networks:
   default:
     driver: bridge
+
+volumes:
+  redis_data:
+    driver: local

--- a/src/main/java/kr/hhplus/be/server/common/annotation/DistributeLock.java
+++ b/src/main/java/kr/hhplus/be/server/common/annotation/DistributeLock.java
@@ -1,0 +1,19 @@
+package kr.hhplus.be.server.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributeLock {
+    String key(); // key: 락의 이름 ex: "'userId:' + #userId"
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS; // timeUnit: 시간 단위(MILLISECONDS, SECONDS, MINUTE..)
+
+    long waitTime() default 5L; // waitTime: 락을 획득하기 위한 대기 시간
+
+    long leaseTime() default 3L; // leaseTime: 락을 임대하는 시간
+}

--- a/src/main/java/kr/hhplus/be/server/common/aop/DistributeLockAop.java
+++ b/src/main/java/kr/hhplus/be/server/common/aop/DistributeLockAop.java
@@ -1,0 +1,54 @@
+package kr.hhplus.be.server.common.aop;
+
+import kr.hhplus.be.server.common.annotation.DistributeLock;
+import kr.hhplus.be.server.config.redisson.AopForTransaction;
+import kr.hhplus.be.server.config.redisson.CustomSpringELParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Aspect
+@Component
+@Order(Ordered.LOWEST_PRECEDENCE-1)// 트랜잭션보다 먼저 시작
+@RequiredArgsConstructor
+@Slf4j
+public class DistributeLockAop {
+    private static final String REDISSON_KEY_PREFIX = "RLOCK_";
+
+    private final RedissonClient redissonClient;
+    private final AopForTransaction aopForTransaction;
+
+    @Around("@annotation(kr.hhplus.be.server.common.annotation.DistributeLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();Method method = signature.getMethod();
+        DistributeLock distributeLock = method.getAnnotation(DistributeLock.class);     // 해당 메서드의 어노테이션을 가져온다
+        String key = REDISSON_KEY_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributeLock.key());    // DistributeLock에 전달한 key와 메서드 인자를 통한 Lock key값생성(Spring EL파싱)
+
+        RLock rLock = redissonClient.getLock(key);
+
+        try {
+            boolean available = rLock.tryLock(distributeLock.waitTime(), distributeLock.leaseTime(), distributeLock.timeUnit());    // 락 획득 시도
+            if (!available) {
+                return false;
+            }
+
+            log.info("get lock success {}" , key);
+            return aopForTransaction.proceed(joinPoint);    // 락과 트랜잭션 순서를 보장하기 위한 클래스
+        } catch (Exception e) {
+            Thread.currentThread().interrupt();
+            throw new InterruptedException();
+        } finally {
+            rLock.unlock();    // 종료 혹은 예외 발생시 Lock 해제
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/config/redisson/AopForTransaction.java
+++ b/src/main/java/kr/hhplus/be/server/config/redisson/AopForTransaction.java
@@ -1,0 +1,17 @@
+package kr.hhplus.be.server.config.redisson;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class AopForTransaction {
+
+    // 기존에 트랜잭션이 있든 없든 무조건 새 트랜잭션을 생성해서 실행
+    // 새로운 트랜잭션을 강제로 시작해 락획득-트랜잭션시작-트랜잭션종료-락해제를 보장해주기 위함
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/config/redisson/CustomSpringELParser.java
+++ b/src/main/java/kr/hhplus/be/server/config/redisson/CustomSpringELParser.java
@@ -1,0 +1,18 @@
+package kr.hhplus.be.server.config.redisson;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringELParser {
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+        return parser.parseExpression(key).getValue(context, Object.class);
+
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/config/redisson/RedissonConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/redisson/RedissonConfig.java
@@ -1,0 +1,28 @@
+package kr.hhplus.be.server.config.redisson;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        RedissonClient redisson = null;
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+        redisson = Redisson.create(config);
+        return redisson;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/concert/ConcertSeat.java
+++ b/src/main/java/kr/hhplus/be/server/domain/concert/ConcertSeat.java
@@ -29,6 +29,10 @@ public class ConcertSeat {
     @JoinColumn(name = "concert_schedule_id")
     private ConcertSchedule concertSchedule;
 
+    @Version
+    @Column(nullable = false)
+    private int version;
+
 
     public void reserved(User user) {
         if(this.status.equals("reserved") || this.status.equals("completed")) throw new IllegalStateException("좌석이 이미 예약되거나 완료된 상태입니다.");

--- a/src/main/java/kr/hhplus/be/server/domain/reservation/Reservation.java
+++ b/src/main/java/kr/hhplus/be/server/domain/reservation/Reservation.java
@@ -33,6 +33,10 @@ public class Reservation {
     private LocalDateTime statusUpdateAt;
     private LocalDateTime expireAt;
 
+    @Version
+    @Column(nullable = false)
+    private int version;
+
     public void completeReservation() {
         if(!this.status.equals("reserved")) throw new IllegalStateException("예약이 예약된 상태여야 합니다.");
         this.status = "completed";

--- a/src/main/java/kr/hhplus/be/server/domain/reservation/ReservationService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/reservation/ReservationService.java
@@ -45,7 +45,7 @@ public class ReservationService {
         }
         reservation.completeReservation();
         log.info("Reservation Status: {}",reservation.getStatus());
-        reservationRepository.save(reservation);
+        reservationRepository.flush();
     }
 
     // 예약만료 스케줄러에서 사용하는 예약만료

--- a/src/main/java/kr/hhplus/be/server/domain/user/User.java
+++ b/src/main/java/kr/hhplus/be/server/domain/user/User.java
@@ -22,6 +22,9 @@ public class User {
     @Column
     private Long balance;
 
+    @Version
+    private int version;
+
     // 잔액 충전
     public void chargeAmount(Long amount) {
         if(amount < 0 || amount > 1000000) {

--- a/src/main/java/kr/hhplus/be/server/domain/user/UserService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/user/UserService.java
@@ -27,7 +27,7 @@ public class UserService {
         User user = userRepository.findById(userId).orElseThrow();
 
         user.chargeAmount(amount);
-        userRepository.save(user);
+        userRepository.flush();
 
         // user 잔액 히스토리 저장
         UserBalanceHistory userBalanceHistory = new UserBalanceHistory();
@@ -53,9 +53,9 @@ public class UserService {
     public UserBalanceHistory makePayment(Long userId, Long price) {
         User user = userRepository.findById(userId).orElseThrow();
 
-        // 잔액 차감
+        // 잔액 차감 versioning 을 통한 동시성 제어중
         user.debitBalance(price);
-        userRepository.save(user);
+        userRepository.flush();
 
         // 사용내역 저장
         UserBalanceHistory userBalanceHistory = new UserBalanceHistory();

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -12,8 +13,11 @@ import org.testcontainers.utility.DockerImageName;
 class TestcontainersConfiguration {
 
 	public static final MySQLContainer<?> MYSQL_CONTAINER;
+	public static final GenericContainer<?> REDIS_CONTAINER;
+
 
 	static {
+		// MYSQL Container
 		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
 			.withDatabaseName("hhplus")
 			.withUsername("test")
@@ -23,12 +27,28 @@ class TestcontainersConfiguration {
 		System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
 		System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
 		System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
+
+		// Redis Container
+		REDIS_CONTAINER = new GenericContainer<>(DockerImageName.parse("bitnami/redis:7.4"))
+				.withExposedPorts(6379)  // default redis port
+				.withEnv("ALLOW_EMPTY_PASSWORD", "yes")
+				.withEnv("REDIS_DISABLE_COMMANDS", "FLUSHDB,FLUSHALL");
+		REDIS_CONTAINER.start();
+
+		String redisHost = REDIS_CONTAINER.getHost();
+		Integer redisPort = REDIS_CONTAINER.getFirstMappedPort();
+
+		System.setProperty("spring.data.redis.host", redisHost);
+		System.setProperty("spring.data.redis.port", redisPort.toString());
 	}
 
 	@PreDestroy
 	public void preDestroy() {
 		if (MYSQL_CONTAINER.isRunning()) {
 			MYSQL_CONTAINER.stop();
+		}
+		if (REDIS_CONTAINER.isRunning()) {
+			REDIS_CONTAINER.stop();
 		}
 	}
 }

--- a/src/test/java/kr/hhplus/be/server/integration/ReservationFacadeConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/ReservationFacadeConcurrencyTest.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.integration;
 
 import kr.hhplus.be.server.application.reservation.ReservationFacade;
+import kr.hhplus.be.server.application.reservation.dto.ReservationResponse;
 import kr.hhplus.be.server.domain.concert.ConcertSchedule;
 import kr.hhplus.be.server.domain.concert.ConcertScheduleRepository;
 import kr.hhplus.be.server.domain.concert.ConcertSeat;
@@ -57,7 +58,7 @@ public class ReservationFacadeConcurrencyTest {
                         .status("available")
                 .build());
 
-        int threadCount = 5;
+        int threadCount = 10;
 
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
@@ -89,7 +90,77 @@ public class ReservationFacadeConcurrencyTest {
                 successCount++;
             }
         }
-        // 검증
+        // 한명만 성공한다
+        Assertions.assertEquals(1,successCount);
+    }
+
+    @Test
+    void 동시_결제시_1번만_성공한다() throws ExecutionException, InterruptedException {
+        // given - 필요 데이터 삽입
+        // 토큰 발급
+        String uuid = queueService.getToken();
+        // 강제 액티브
+        queueService.activateTokens();
+        // 유저 저장
+        User user = userRepository.save(User.builder()
+                .balance(10000L)
+                .username("testUser")
+                .build());
+        // 콘서트 스케줄 저장
+        ConcertSchedule concertSchedule = concertScheduleRepository.save(ConcertSchedule.builder()
+                .concertDate(LocalDate.now())
+                .build());
+        // 콘서트 좌석 저장
+        ConcertSeat concertSeat = concertSeatRepository.save(ConcertSeat.builder()
+                .seatNo(1L)
+                .price(5000L)
+                .concertSchedule(concertSchedule)
+                .status("available")
+                .build());
+
+        // 예약 처리
+        ReservationResponse response = reservationFacade.reserveSeat(user.getId(), concertSchedule.getId(), concertSeat.getSeatNo());
+
+        Long userId = user.getId();
+        Long concertSeatId = concertSeat.getId();
+        Long reservationId = response.getId();
+        String tokenUuid = uuid;
+
+        int threadCount = 10;
+
+        // when
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        List<Future<Boolean>> results = new ArrayList<>();
+
+        for(int i =0; i<threadCount;i++){
+            results.add(executorService.submit(()->{
+
+                try {
+                    reservationFacade.makeSeatPayment(userId,concertSeatId,reservationId,tokenUuid);
+                    return true;
+                } catch (Exception e){
+                    return false;
+                } finally {
+                    latch.countDown();
+                }
+            }));
+        }
+        // 대기
+        latch.await();
+        // 작업종료
+        executorService.shutdown();
+
+        // 성공 카운팅
+        int successCount = 0;
+        for(Future<Boolean>  result:results){
+            if(result.get()){
+                successCount++;
+            }
+        }
+        // then
+        // 한명만 성공한다
         Assertions.assertEquals(1,successCount);
     }
 

--- a/src/test/java/kr/hhplus/be/server/integration/UserFacadeConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/UserFacadeConcurrencyTest.java
@@ -1,0 +1,88 @@
+package kr.hhplus.be.server.integration;
+
+import kr.hhplus.be.server.application.user.UserFacade;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.domain.user.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+@SpringBootTest
+public class UserFacadeConcurrencyTest {
+
+
+    @Autowired
+    private UserFacade userFacade;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private static final Logger log = LoggerFactory.getLogger(UserFacadeConcurrencyTest.class);
+
+    @Test
+    void 여러번_충전하면_성공한횟수만큼_금액이_저장된다_동시성테스트() throws InterruptedException, ExecutionException {
+        // given
+        List<Future<Boolean>> results = new ArrayList<>();
+
+        User user = userRepository.save(User.builder()
+                .username("testUser")
+                .balance(0L)
+                .build());
+
+        long amount = 50000L;
+
+        long startTime = System.currentTimeMillis();
+        // thread 수
+        int threadCount = 10;
+
+        // when
+        ExecutorService executorService = Executors.newFixedThreadPool(5);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        for(int i=0;i<threadCount;i++){
+            results.add(executorService.submit(()-> {
+                        try {
+                            userFacade.chargeAmount(user.getId(), amount);
+                            return true;
+                        } catch (Exception e) {
+                            return false;
+                        } finally {
+                            latch.countDown();
+                        }
+                    }
+            ));
+        }
+
+        // 서브스레드 완료전까지 메인스레드 정지
+        latch.await();
+        // 스레드 종료
+        executorService.shutdown();
+
+        long endTime = System.currentTimeMillis();
+        log.info("service take time: {}",endTime-startTime);
+
+        // then
+        // 성공 카운팅
+        int successCount = 0;
+        for(Future<Boolean>  result:results){
+            if(result.get()){
+                successCount++;
+            }
+        }
+
+        // 저장된 유저 조회
+        User savedUser = userRepository.findById(user.getId()).orElseThrow();
+
+        // 성공 카운팅에 따른 금액이 정확하게 들어갔는지 확인
+        long totalAmount = successCount*amount;
+        log.info("successCount is {}",successCount);
+        Assertions.assertEquals(totalAmount,savedUser.getBalance());
+    }
+}
+


### PR DESCRIPTION
### STEP 11

## [동시성 제어 보고서(블로그)](https://velog.io/@babyslayerr/%EB%8F%99%EC%8B%9C%EC%84%B1-%EC%A0%9C%EC%96%B4)

[분산락 적용하기(위 보고서에 포함되어있음)](https://velog.io/@babyslayerr/%EB%B6%84%EC%82%B0%EB%9D%BDRedisson-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0)

### STEP 12

**동시성 제어를 위한 Lock 추가**
- 예약 결제 서비스의 동시성 제어를 위한 낙관적 락 추가 : 9ad3d7a2bd8b1c2ba658cab2317713468b9ef030
- 유저 충전 서비스의 동시성 제어를 위한 낙관적 락 추가 : 294fd80beb668fc07e7c4819268d7526322178f4
- 좌석 예약 서비스의 동시성 제어를 위한 낙관적 락 추가 : 4ab92ce76a13e4e060d34122633a7b5a50cc86b3

**통합 테스트 추가**
- 유저 충전 서비스의 동시성 테스트 추가 : a3e452bd1c07010d54f8db14bb79a732354babd7 
- 예약 결제 서비스의 동시성 테스트 추가 : 7edfaedf98b3aada452460c786a3a664e5c6f487

**분산 락 환경 설정** 
- 분산 락 어노테이션 처리를 위한 AOP 추가 : 76aac0b8e1176efb6d11d7cc41b1a88da4ef312d
- 분산 락 어노테이션 추가 : a4a2c9a336b8a41ae199ad059b51712ba9e3a27b
- Redisson Config 파일 추가 : 4c66270a55b4227e00ac314b4d3b1e1f652f0ba6
- Redis 도커 환경 설정, 테스트 컨테이너 설정 추가 : 67517884af9f42187d7ff3b2ffd702530aa2af2b
- 분산 락 사용을 위한 Redisson 의존성 추가 : 5c209ba340bf3c9c6aea9b75c3eb06c2c9b72ec9

---
### **리뷰 포인트(질문)**
- 보통 Redis를 사용하는 인프라의 경우 분산환경에서 Redis를 사용할 때 Redis만을 위한 별도의 서버를 구축하나요??
  
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
커밋 로그 잘 짜기
### Problem
<!--개선이 필요한 점-->
마지막 까지 최선을 다하기, 스스로 생각 많이 하고 정리하기
### Try
<!-- 새롭게 시도할 점 -->
미리미리 하기