### PR TITLE
STEP15+STEP16

### DIFF
--- a/src/main/java/kr/hhplus/be/server/common/event/CompletedPaymentEvent.java
+++ b/src/main/java/kr/hhplus/be/server/common/event/CompletedPaymentEvent.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.common.event;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CompletedPaymentEvent {
+    private final Long reservationId;
+    private final Long userId;
+    private final Long seatId;
+    private final Long price;
+}

--- a/src/main/java/kr/hhplus/be/server/common/event/CompletedReservationEvent.java
+++ b/src/main/java/kr/hhplus/be/server/common/event/CompletedReservationEvent.java
@@ -1,0 +1,13 @@
+package kr.hhplus.be.server.common.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CompletedReservationEvent {
+    private final Long reservationId;
+    private final Long userId;
+    private final Long seatId;
+    private final Long price;
+}

--- a/src/main/java/kr/hhplus/be/server/common/event/listener/ExternalApiSender.java
+++ b/src/main/java/kr/hhplus/be/server/common/event/listener/ExternalApiSender.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.common.event.listener;
+
+import kr.hhplus.be.server.common.event.CompletedPaymentEvent;
+import kr.hhplus.be.server.common.event.CompletedReservationEvent;
+import kr.hhplus.be.server.common.external.ExternalApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ExternalApiSender {
+    private final ExternalApiClient externalApiClient;
+    @TransactionalEventListener
+    public void sendReservationInfo(CompletedReservationEvent event) {
+        externalApiClient.sendReservationInfo(event.getReservationId(), event.getUserId(), event.getSeatId(), event.getPrice());
+    }
+    @TransactionalEventListener
+    public void sendPaymentInfo(CompletedPaymentEvent event) {
+        externalApiClient.sendPaymentInfo(event.getReservationId(), event.getUserId(), event.getSeatId(), event.getPrice());
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/common/external/ExternalApiClient.java
+++ b/src/main/java/kr/hhplus/be/server/common/external/ExternalApiClient.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.common.external;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExternalApiClient {
+    public void sendReservationInfo(Long reservationId, Long userId, Long seatId, Long price) {
+        System.out.printf("외부 API 호출 - 예약 ID: %d, 유저 ID: %d, 좌석 ID: %d, 가격: %d%n",
+                reservationId, userId, seatId, price);
+    }
+
+    public void sendPaymentInfo(Long reservationId, Long userId, Long seatId, Long price) {
+        System.out.printf("외부 API 호출 - 예약 ID: %d, 유저 ID: %d, 좌석 ID: %d, 가격: %d%n",
+                reservationId, userId, seatId, price);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
     generate-ddl: false
     show-sql: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC


### PR DESCRIPTION
### STEP 15
[인덱스 추가 보고서](https://velog.io/@babyslayerr/DB%EC%9D%B8%EB%8D%B1%EC%8A%A4INDEX%EB%A5%BC-%ED%86%B5%ED%95%9C-%EC%B5%9C%EC%A0%81%ED%99%94)

### STEP 16
[트랜잭션 분리 보고서](https://velog.io/@babyslayerr/%ED%8A%B8%EB%9E%9C%EC%9E%AD%EC%85%98-%EB%B6%84%EB%A6%AC%EC%97%90-%EB%94%B0%EB%A5%B8-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%9D%BC%EA%B4%80%EC%84%B1-%EB%B3%B4%EC%9E%A5%ED%95%98%EA%B8%B0)

#### 예약 및 결제데이터를 데이터 플랫폼에 전송
- 예약완료 이벤트 클래스 추가 :  ea8b9ca9c747769dc66b69a491781f2e20b1a1bc
- 결제완료 이벤트 클래스 추가 : 09e0738f456f48ce84f697a641ea60f583ad7dad
- 이벤트 리스너 추가 : f55ed86005e7aa9f2427b132e40e631e2f4e5adf
- 외부 API Client 추가  : 97e81dc038a24bed4c6e63d18ef96d76000333de
- 예약 및 결제 로직에 플랫폼 전송 로직 추가(이벤트) : f5a23fef30551a9f7553a2f60dc4861aa2a85d37

---
### **리뷰 포인트(질문)**
- 이벤트 관련 파일들을 common에 넣었는데 괜찮을까요??(application에서 사용되는 도메인 관련 패키지가 아닌 common에서 사용되는 기술이라 생각하였습니다)
- 위 질문과 비슷하게 외부 API Client도 common패키지에 넣었는데 괜찮을까요?
- facade 메서드에 이벤트 발행 추가로직을 추가했습니다. (f5a23fef30551a9f7553a2f60dc4861aa2a85d37)
- 위 사항과 관련해서 다른분들 언뜻 들어보니까 facade계층없이 service만 호출만 하는경우도 있다 들었습니다(잘 못 들은걸 수도있습니다) 이럴때, 순환참조의 위험성이 증가하지만 service에서 다른 service로 직접 호출을 하는 경우도 많이 있나요??(저는 사실 facade계층을 이번 항해하면서 처음들어봤었습니다, 제경우에는 대부분 service-> service 호출의 경우만 봤습니다)
- 오케스트레이션 기반 사가는 facade계층대신 오케스트레이터가 facade 역할을 대신하는건가요(controller->오케스트레이터)? 그리고  코레오그래피 기반 사가도 컨트롤러가 facade없이 서비스를 바로 호출해도 될 것 같은데 제 생각이 맞는지 궁금합니다.

### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
포기하지 않기
### Problem
<!--개선이 필요한 점-->
잠 보통만 자기
### Try
<!-- 새롭게 시도할 점 -->
계속 궁금해하기